### PR TITLE
feat(wordchart): add interactivity indicators

### DIFF
--- a/src/patterns/WordChart/WordChart.vue
+++ b/src/patterns/WordChart/WordChart.vue
@@ -6,10 +6,10 @@
     <a
       v-for='word in chartWords'
       :key='word.text'
-      class='inline-block mx-1'
+      :class='wordClasses(word)'
       :style='`color: ${word.color}; font-size: ${word.fontSize}${fontSizeUnits}`'
       :title='`${word.text} (${word.frequency})`'
-      @click='$emit("selectWord", { word: word.text, frequency: word.frequency })'
+      @click='onClickWord(word)'
     >
       {{ word.text }}
     </a>
@@ -114,6 +114,13 @@ export default {
       type: Boolean,
       default: false,
     },
+    /**
+     * Words appear clickable. Disabling will remove cursor pointer, hover state, and prevent event `@selectWord` from emitting
+     */
+    wordsAreInteractive: {
+      type: Boolean,
+      default: true,
+    },
   },
   computed: {
     frequencies() {
@@ -168,8 +175,28 @@ export default {
       })
     },
   },
+  methods: {
+    onClickWord(word) {
+      if (this.wordsAreInteractive) {
+        this.$emit('selectWord', { word: word.text, frequency: word.frequency })
+      }
+    },
+    wordClasses(word) {
+      const interactivity = this.wordsAreInteractive ? 'interactive' : ''
+      return `inline-block mx-1 word-chart-word ${interactivity}`
+    },
+  },
 }
 </script>
+
+<style lang="scss">
+.word-chart-word { cursor: default }
+.word-chart-word.interactive {
+  cursor: pointer;
+  &:hover { filter: brightness(120%) }
+}
+</style>
+
 
 <docs>
   ```jsx

--- a/src/patterns/WordChart/__tests__/wordChart.spec.js
+++ b/src/patterns/WordChart/__tests__/wordChart.spec.js
@@ -34,14 +34,6 @@ describe('WordChart.vue', () => {
     expect(goodbye.element.style['font-size']).toBe('1rem')
   })
 
-  it('emits the word and count when a word is clicked', () => {
-    const text = buildText({ hello: 20, goodbye: 10 })
-    const wrapper = mountWordChart({ text, maximumFontSize: 2 })
-    const wordChartWords = wrapper.find('.word-chart').find('a').trigger('click')
-
-    expect(wrapper.emitted('selectWord')).toEqual([[{ frequency: 20,  word: 'hello' }]])
-  })
-
   it('displays the most frequent words limited by maxWordsShown', () => {
     const text = buildText({ hello: 20, goodbye: 10, howdy: 15, aloha: 18, sayonara: 30 })
     const wrapper = mountWordChart({ text, maxWordsShown: 4 })
@@ -102,5 +94,23 @@ describe('WordChart.vue', () => {
     const WHITESPACE = /\s+/
     const wordChartTexts = wrapper.find('.word-chart').text().split(WHITESPACE)
     expect(wordChartTexts).toEqual(['its', 'nonhello', 'how', 'doyou', 'do'])
+  })
+
+  it('emits the word and count when a word is clicked', () => {
+    const text = buildText({ hello: 20, goodbye: 10 })
+    const wrapper = mountWordChart({ text })
+    const wordChartWords = wrapper.find('.word-chart').find('a').trigger('click')
+
+    expect(wrapper.emitted('selectWord')).toEqual([[{ frequency: 20,  word: 'hello' }]])
+  })
+
+  describe('when wordsAreInteractive is false', () => {
+    it('emits the word and count when a word is clicked', () => {
+      const text = buildText({ hello: 20, goodbye: 10 })
+      const wrapper = mountWordChart({ text, wordsAreInteractive: false })
+      const wordChartWords = wrapper.find('.word-chart').find('a').trigger('click')
+  
+      expect(wrapper.emitted('selectWord')).toEqual(undefined)
+    })
   })
 })


### PR DESCRIPTION
### Overview
Add interactivity indicators to WordChart


### Changes
- add prop `wordsAreInteractive`

#### UI
When active
![hoverstate](https://user-images.githubusercontent.com/3292124/62650495-db81b380-b90b-11e9-8b85-e727c39ab148.gif)

When disabled
![nohoverstate](https://user-images.githubusercontent.com/3292124/62650496-db81b380-b90b-11e9-95be-5fcecc0c8361.gif)
