### PR TITLE
feat(navbar): improvements to function and style of navbar

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3,10 +3,10 @@
 import Vue from 'vue'
 import App from '@/App'
 import router from '@/router'
-import WebFontLoader from '@/utils/webFontLoader' // eslint-disable-line no-unused-vars
 import Meta from 'vue-meta'
 import Buefy from 'buefy'
 import DesignSystem from '@/system'
+import '@/utils/webFontLoader'
 
 Vue.use(Buefy, { defaultIconPack: 'fa' })
 Vue.use(DesignSystem)

--- a/src/patterns/NavBar.vue
+++ b/src/patterns/NavBar.vue
@@ -1,9 +1,12 @@
 <template>
   <component
     :is='type'
-    :class='`flex items-center justify-between flex-wrap pl-3 shadow nav-bar`'
+    :class='`flex items-center justify-between pl-1 md:pl-3 shadow nav-bar ${colorClass}`'
   >
-    <div class='flex items-center flex-shrink-0 mr-4 p-3'>
+    <div
+      v-if='showHeading'
+      class='flex items-center flex-shrink-0 p-3 md:mr-4'
+    >
       <slot name='heading'>
         <a :href='headerLink'>
           <h1
@@ -19,22 +22,9 @@
         </a>
       </slot>
     </div>
-    <div class='block md:hidden'>
-      <button
-        class='flex items-center px-3 py-2 rounded hover:text-white'
-        @click='open = !open'
-      >
-        <Icon name='menu' />
-      </button>
-    </div>
-    <div
-      :class='{
-        flex: open,
-        hidden: !open,
-      }'
-      class='md:flex flex-grow w-full md:items-stretch md:w-auto min-h-16'
-    >
-      <div class='flex flex-grow'>
+    <div class='flex flex-grow items-stretch w-auto min-h-16'>
+      <div class='flex-grow md:hidden' />
+      <div class='flex md:flex-grow'>
         <slot name='left' />
       </div>
       <div class='flex'>
@@ -43,30 +33,6 @@
     </div>
   </component>
 </template>
-
-<style lang="scss">
-.swayable-logo {
-  min-width: 250px;
-}
-
-.nav-bar {
-  background-color: $dark;
-  color: $light;
-  .swayable-logo {
-    background-image: url(https://images.swayable.com/logos/dark.svg?v=1)
-  }
-}
-
-.theme-dark {
-  .nav-bar {
-    background-color: $light;
-    color: $dark;
-    .swayable-logo {
-      background-image: url(https://images.swayable.com/logos/light.svg?v=1)
-    }
-  }
-}
-</style>
 
 <script>
 /**
@@ -81,9 +47,6 @@ export default {
   name: 'NavBar',
   status: 'under-review',
   release: '0.1.0',
-  model: {
-    prop: 'active',
-  },
   props: {
     /**
      * href of heading (unavailable if using heading slot)
@@ -108,34 +71,83 @@ export default {
       required: false,
       default: null,
     },
+    /**
+     * Used to remove heading/logo
+     */
+    noheading: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * Changes the style to a light background
+     */
+    light: {
+      type: Boolean,
+      default: false,
+    },
   },
-  data() {
-    return { open: false }
+  computed: {
+    showHeading() {
+      return this.noheading === false
+    },
+    colorClass() {
+      return this.light !== false
+        ? 'nav-light'
+        : ''
+    },
   },
 }
 </script>
 
+
+<style lang="scss">
+.nav-bar {
+  $small-logo-url: url(https://images.swayable.com/logos/motif.svg);
+  $dark-logo-url: url(https://images.swayable.com/logos/dark.svg);
+  $light-logo-url: url(https://images.swayable.com/logos/light.svg);
+  
+  background-color: $dark;
+  color: $light;
+
+  &.nav-light {
+    background-color: $light;
+    color: $dark;
+  }
+
+  .swayable-logo {
+    width: 40px;
+    background-image: $small-logo-url;
+  }
+
+  @media (min-width: 640px) {
+    .swayable-logo {
+      width: 250px;
+      background-image: $dark-logo-url;
+    }
+    &.nav-light {
+      .swayable-logo { background-image: $light-logo-url; }
+    }
+  }
+}
+</style>
+
 <docs>
   ```jsx
-  <section>
-    <NavBar headerLink='/#/Patterns/NavBar'>
-      <template #left>
-        <NavItem name='Dashboard' active='true' />
-      </template>
-      <template>
-        <NavItem name='Sign in' />
-      </template>
-    </NavBar>
-  </section>
-  <section class='theme-dark'>
-    <NavBar headerLink='/#/Patterns/NavBar'>
-      <template #left>
-        <NavItem name='Dashboard' active='true' />
-      </template>
-      <template>
-        <NavItem name='Sign in' />
-      </template>
-    </NavBar>
-  </section>
+  <NavBar headerLink='/#/Patterns/NavBar'>
+    <template #left>
+      <NavItem name='Dashboard' active='true' />
+    </template>
+    <template>
+      <NavItem name='Sign in' />
+    </template>
+  </NavBar>
+  <NavBar headerLink='/#/Patterns/NavBar' light>
+    <template #left>
+      <NavItem name='Dashboard' active='true' />
+    </template>
+    <template>
+      <NavItem name='Sign in' />
+    </template>
+  </NavBar>
   ```
 </docs>

--- a/src/patterns/NavBar.vue
+++ b/src/patterns/NavBar.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is='type'
-    :class='`flex items-center justify-between pl-1 md:pl-3 shadow nav-bar ${colorClass}`'
+    :class='`flex items-center justify-between pl-1 md:pl-3 shadow z-20 nav-bar ${colorClass}`'
   >
     <div
       v-if='showHeading'

--- a/src/patterns/NavDrop.vue
+++ b/src/patterns/NavDrop.vue
@@ -4,7 +4,8 @@
     class='relative'
   >
     <NavItem
-      type='a'
+      type='button'
+      aria-label='Expand Menu'
       @click='toggleOpen'
       v-on='$listeners'
     >
@@ -95,10 +96,7 @@ export default {
 <style lang="scss">
 .nav-drop {
   background-color: $dark;
-  .nav-item.active {
-    border-bottom: 0;
-    border-right-width: 4px;
-  }
+  .nav-item.active { border-bottom: 0; }
 }
 .theme-dark {
   .nav-drop {
@@ -110,8 +108,8 @@ export default {
 <docs>
   ```jsx
   <NavBar>
-    <NavItem name="Link" />
-    <NavDrop name="Links Menu" :navItems='[
+    <NavItem href='/' name="Link" />
+    <NavDrop name="Menu" :navItems='[
         { name: "Item 1" },
         { name: "Item 2", active: "true" },
         { name: "Item 3" },
@@ -119,7 +117,7 @@ export default {
     />
     <NavDrop>
       Account &nbsp;
-      <Icon name="chevron-down" size="small" ariaLabel="Expand Menu" />
+      <Icon name="chevron-down" size="small" />
       <template #dropdown>
         <NavItem name="Profile" />
         <NavItem name="Settings" />

--- a/src/patterns/NavDrop.vue
+++ b/src/patterns/NavDrop.vue
@@ -14,7 +14,7 @@
     <div
       v-show='open'
       ref='navMenuDropdown'
-      class='w-screen lg:w-auto min-w-full absolute right-0 flex-col nav-drop z-20'
+      class='w-screen md:w-auto min-w-full absolute right-0 flex-col nav-drop z-30'
     >
       <slot name='dropdown'>
         <NavItem

--- a/src/patterns/NavItem.vue
+++ b/src/patterns/NavItem.vue
@@ -1,13 +1,12 @@
 <template>
   <component
-    :is='type'
-    ref='navItem'
-    :href='href'
+    :is='smartType'
+    v-bind='navigation'
     :class='{
       "pb-3 lg:pb-2 active": isActive,
     }'
     :title='title'
-    class='h-full whitespace-no-wrap flex p-4 lg:py-3 ml-1 cursor-pointer font-medium items-center nav-item'
+    class='h-full whitespace-no-wrap flex p-4 lg:py-3 ml-1 font-medium items-center nav-item'
     v-on='$listeners'
   >
     <slot>
@@ -31,6 +30,13 @@ export default {
     type: {
       type: String,
       default: 'a',
+    },
+    /**
+     * If provided, type will default to `router-link`
+     */
+    to: {
+      type: Object,
+      default: null,
     },
     /**
      * The destination address
@@ -61,29 +67,39 @@ export default {
     isActive() {
       return this.active === 'true'
     },
+    smartType() {
+      if (this.type === 'a' && this.to !== null) return 'router-link'
+      return this.type
+    },
+    navigation() {
+      if (this.smartType === 'router-link') return { to: (this.to || this.href) }
+      if (this.href) return { href: this.href }
+      return {}
+    },
   },
 }
 </script>
 
 <style lang="scss">
+a.nav-item, button.nav-item { cursor: pointer }
 .nav-item {
   color: $gray-400;
   &:hover, &:active, &:focus {
     color: $gray-200;
   }
-  &.active {
+  &.active, &.router-link-active {
     border-bottom-width: 4px;
     border-style: solid;
     border-color: $gray-400;
   }
 }
-.theme-dark {
+.nav-light {
   .nav-item {
     color: $gray-700;
     &:hover, &:active, &:focus {
       color: $dark;
     }
-    &.active {
+    &.active, &.router-link-active  {
       border-color: $gray-600;
     }
   }
@@ -94,11 +110,9 @@ export default {
   ```jsx
   <div>
     <NavBar>
-      <template #right>
-        <NavItem href="/#/" name="Item 1" active='true' />
-        <NavItem href="/#/" name="Item 2" title="The only item with a title" />
-        <NavItem href="/#/">Item 3</NavItem>
-      </template>
+      <NavItem href='/#/' name='Item 1' active='true' />
+      <NavItem href='/#/' name='Item 2' title='The only item with a title' />
+      <NavItem href='/#/'>Item 3</NavItem>
     </NavBar>
   </div>
   ```


### PR DESCRIPTION
### Overview
Fixes a bunch of problems I ran into when integrating the navbar with swayable/swayable-app

### Changes
- add prop `noheading` which removes the heading from the navbar
- add prop `light` which changes the background of the navbar to light
- removed `.theme-dark` styles (Gabe's dark theme mockups don't actually change the color of the nav. Though now thinking about this further, we might need to do something with `light` if using theme-dark.)
- removed the standard hamburger menu and made the menu act like the current swayable navbar where the logo just minimized to the motif
- changed nav-items to work with router-links
- fixed aria label on navdrop
- fixed cursor on nav-item to only be pointer if the elment is `a` or `button`

### UI
#### Implementation
<img width="398" alt="image" src="https://user-images.githubusercontent.com/3292124/62667219-91182b00-b93b-11e9-9a2b-26a351cf55aa.png">

<img width="913" alt="image" src="https://user-images.githubusercontent.com/3292124/62667224-9aa19300-b93b-11e9-876d-d54d5c1cbdf9.png">

#### Docs
<img width="1234" alt="image" src="https://user-images.githubusercontent.com/3292124/62667414-67133880-b93c-11e9-9f5d-7e047f5a656f.png">


