### PR TITLE
chore(releases): build distribution as part of release

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "theo:onchange": "onchange \"./src/tokens/*.yml\" -- npm run theo",
     "test": "npm-run-all theo unit",
     "commit": "yarn lint --fix && git-cz",
-    "release": "standard-version"
+    "release": "npm-run-all theo node:build:system && git commit -a -m 'chore(pre-release): build system distribution' && standard-version"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
#### Addresses the issue of tagging a release without having build the dist yet

Results in this `git log`
![image](https://user-images.githubusercontent.com/3292124/62667471-a17cd580-b93c-11e9-8164-cbaf598142d4.png)

#### Thoughts
- Ideally we could avoid checking in the `/dist` directory altogther. I'm not sure how it would still be available in git or npm like this
- There's another adjacent issue of updating the version of tokens/elements/patterns that have changed since the last version which I don't have a solution for. But I haven't really investigated it either so 🤷‍♂ 