### PR TITLE
[wip] dropdown pattern

### DIFF
--- a/src/elements/Input.vue
+++ b/src/elements/Input.vue
@@ -8,6 +8,7 @@
     :placeholder='placeholder'
     @input='onInput($event.target.value)'
     @focus='onFocus($event.target.value)'
+    @click='onClick($event.target.value)'
   >
 </template>
 
@@ -83,6 +84,9 @@ export default {
     },
     onFocus(value) {
       this.$emit('focus', value)
+    },
+    onClick(value) {
+      this.$emit('click', value)
     },
   },
 }

--- a/src/elements/Input.vue
+++ b/src/elements/Input.vue
@@ -1,25 +1,14 @@
 <template>
-  <component
-    :is='wrapper'
-    :class='["input", { "input-expand": width === "expand" }]'
+  <input
+    :id='id'
+    :disabled='disabled'
+    :type='type'
+    :value='value'
+    :class='["p-2", "rounded", style]'
+    :placeholder='placeholder'
+    @input='onInput($event.target.value)'
+    @focus='onFocus($event.target.value)'
   >
-    <label
-      v-if='label'
-      :for='id'
-    >
-      {{ label }}
-    </label>
-    <input
-      :id='id'
-      :disabled='disabled'
-      :type='type'
-      :value='value'
-      :class='state'
-      :placeholder='placeholder'
-      @input='onInput($event.target.value)'
-      @focus='onFocus($event.target.value)'
-    >
-  </component>
 </template>
 
 <script>
@@ -59,40 +48,11 @@ export default {
       default: null,
     },
     /**
-     * The label of the form input field.
-     */
-    label: {
-      type: String,
-      default: null,
-    },
-    /**
-     * The html element name used for the wrapper.
-     * `div, section`
-     */
-    wrapper: {
-      type: String,
-      default: 'div',
-      validator: value => {
-        return value.match(/(div|section)/)
-      },
-    },
-    /**
      * Unique identifier of the form input field.
      */
     id: {
       type: String,
       default: null,
-    },
-    /**
-     * The width of the form input field.
-     * `auto, expand`
-     */
-    width: {
-      type: String,
-      default: 'expand',
-      validator: value => {
-        return value.match(/(auto|expand)/)
-      },
     },
     /**
      * Whether the form input field is disabled or not.
@@ -102,16 +62,19 @@ export default {
       type: Boolean,
       default: false,
     },
-    /**
-     * Manually trigger various states of the input.
-     * `hover, active, focus`
-     */
-    state: {
-      type: String,
-      default: null,
-      validator: value => {
-        return value.match(/(hover|active|focus)/)
-      },
+  },
+  computed: {
+    style() {
+      if (this.disabled) return ['cursor-not-allowed', 'text-grey']
+
+      return [
+        'shadow-inner',
+        'focus:shadow-outline',
+        'border',
+        'border-grey-0',
+        'hover:border-grey',
+        'focus:border-blue',
+      ]
     },
   },
   methods: {
@@ -128,10 +91,8 @@ export default {
 <docs>
   ```jsx
   <div>
-    <Input label="Default input" placeholder="Write your text" id="input-1" />
-    <Input label=":hover" state="hover" placeholder="Write your text" id="input-2" />
-    <Input label=":focus" state="focus" placeholder="Write your text" id="input-3" />
-    <Input label="[disabled]" disabled value="Write your text" id="input-4" />
+    <Input placeholder="Default Input" id="input-1" />
+    <Input disabled value="Disabled" id="input-4" />
   </div>
   ```
 </docs>

--- a/src/patterns/Dropdown/Dropdown.vue
+++ b/src/patterns/Dropdown/Dropdown.vue
@@ -1,0 +1,104 @@
+// Parts of this component are derived from the Buefy project, whose license is
+// included below:
+//
+// MIT License
+//
+// Copyright (c) 2017-2019 Rafael Beraldo
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+<template>
+  <div class='inline-block'>
+    <div @click='toggle'>
+      <slot name='trigger' />
+    </div>
+
+    <div
+      v-show='isActive'
+      class='relative'
+    >
+      <div class='absolute top-0 left-0 z-10 w-full'>
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Dropdown',
+  status: 'prototype',
+  release: '0.5.0',
+  data() {
+    return {
+      isActive: false,
+    }
+  },
+  created() {
+    document.addEventListener('click', this.onBlurClick)
+  },
+  beforeDestroy() {
+    document.removeEventListener('click', this.onBlurClick)
+  },
+  methods: {
+    onBlurClick(evt) {
+      this.isActive = false
+    },
+    toggle() {
+      // if not active, toggle after clickOutside event
+      // this fixes toggling programmatic
+      this.$nextTick(() => {
+        const value = !this.isActive
+        this.isActive = value
+        // Vue 2.6.x ???
+        setTimeout(() => (this.isActive = value))
+      })
+    },
+    selectItem(value) {
+      this.$emit('change', value)
+    },
+  },
+}
+</script>
+
+<docs>
+  ```jsx
+  <div>
+    <Dropdown>
+      <Input slot='trigger' placeholder='Search' />
+
+      <DropdownMenu :max-height='120'>
+        <DropdownItem value='option_1'>
+          <p>Option A</p>
+        </DropdownItem>
+        <DropdownItem value='option_2'>
+          <p>Option B</p>
+        </DropdownItem>
+        <DropdownItem value='option_3'>
+          <p>Option C</p>
+        </DropdownItem>
+        <DropdownItem value='option_4'>
+          <p>Option D</p>
+        </DropdownItem>
+      </DropdownMenu>
+    </Dropdown>
+  </div>
+  ```
+</docs>
+

--- a/src/patterns/Dropdown/DropdownItem.vue
+++ b/src/patterns/Dropdown/DropdownItem.vue
@@ -1,0 +1,51 @@
+<template>
+  <div
+    class='p-2 hover:bg-grey-100'
+    @click='onClick'
+  >
+    <slot />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'DropdownItem',
+  status: 'prototype',
+  release: '0.5.0',
+  props: {
+    value: {
+      type: [Boolean, String, Number, Array, Object],
+    },
+  },
+  methods: {
+    onClick(value) {
+      this.$parent.selectItem(this.value)
+    },
+  },
+}
+</script>
+
+<docs>
+  ```jsx
+  <div>
+    <Dropdown>
+      <Input slot='trigger' placeholder='Search' />
+
+      <DropdownMenu :max-height='120'>
+        <DropdownItem value='option_1'>
+          <p>Option A</p>
+        </DropdownItem>
+        <DropdownItem value='option_2'>
+          <p>Option B</p>
+        </DropdownItem>
+        <DropdownItem value='option_3'>
+          <p>Option C</p>
+        </DropdownItem>
+        <DropdownItem value='option_4'>
+          <p>Option D</p>
+        </DropdownItem>
+      </DropdownMenu>
+    </Dropdown>
+  </div>
+  ```
+</docs>

--- a/src/patterns/Dropdown/DropdownMenu.vue
+++ b/src/patterns/Dropdown/DropdownMenu.vue
@@ -1,0 +1,62 @@
+<template>
+  <div
+    class='bg-white overflow-y-auto rounded shadow pt-1 mt-px border-grey-200 border'
+    :style='style'
+  >
+    <slot />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'DropdownMenu',
+  status: 'prototype',
+  release: '0.5.0',
+  props: {
+    /**
+     * The maximum allowable height of this dropdown menu, in pixels
+     */
+    maxHeight: {
+      type: Number,
+      default: 200,
+    },
+  },
+  computed: {
+    style() {
+      return {
+        'max-height': `${this.maxHeight}px`,
+      }
+    },
+  },
+  methods: {
+    selectItem(value) {
+      this.$parent.selectItem(value)
+    },
+  },
+}
+</script>
+
+<docs>
+  ```jsx
+  <div>
+    <Dropdown>
+      <Input slot='trigger' placeholder='Search' />
+
+      <DropdownMenu :max-height='120'>
+        <DropdownItem value='option_1'>
+          <p>Option A</p>
+        </DropdownItem>
+        <DropdownItem value='option_2'>
+          <p>Option B</p>
+        </DropdownItem>
+        <DropdownItem value='option_3'>
+          <p>Option C</p>
+        </DropdownItem>
+        <DropdownItem value='option_4'>
+          <p>Option D</p>
+        </DropdownItem>
+      </DropdownMenu>
+    </Dropdown>
+  </div>
+  ```
+</docs>

--- a/src/templates/Index.vue
+++ b/src/templates/Index.vue
@@ -131,6 +131,63 @@
 
       <section>
         <Heading type='h2'>
+          Dropdown
+        </Heading>
+
+        <code>
+          <pre>
+&lt;Dropdown @change='onChange'&gt;
+  &lt;Input
+    slot='trigger'
+    placeholder='Search
+  /&gt;
+
+  &lt;DropdownMenu max-height='120'&gt;
+    &lt;DropdownItem value='option_1'&gt;
+      &lt;span&gt;Option A&lt;/span&gt;
+    &lt;/DropdownItem&gt;
+
+    &lt;DropdownItem value='option_2'&gt;
+      &lt;span&gt;Option B&lt;/span&gt;
+    &lt;/DropdownItem&gt;
+
+    &lt;DropdownItem value='option_3'&gt;
+      &lt;span&gt;Option C&lt;/span&gt;
+    &lt;/DropdownItem&gt;
+
+    &lt;DropdownItem value='option_4'&gt;
+      &lt;span&gt;Option D&lt;/span&gt;
+    &lt;/DropdownItem&gt;
+  &lt;/DropdownMenu&gt;
+&lt;/Dropdown&gt;
+          </pre>
+        </code>
+
+        <Dropdown @change='onChange'>
+          <Input
+            slot='trigger'
+            placeholder='Search'
+          />
+
+          <DropdownMenu :max-height='120'>
+            <DropdownItem value='option_1'>
+              <p>Option A</p>
+            </DropdownItem>
+            <DropdownItem value='option_2'>
+              <p>Option B</p>
+            </DropdownItem>
+            <DropdownItem value='option_3'>
+              <p>Option C</p>
+            </DropdownItem>
+            <DropdownItem value='option_4'>
+              <p>Option D</p>
+            </DropdownItem>
+          </DropdownMenu>
+        </Dropdown>
+      </section>
+
+      <section>
+        <Heading type='h2'>
           Form Controls
         </Heading>
 
@@ -201,6 +258,9 @@ export default {
     if (toggleTheme) this.toggleTheme()
   },
   methods: {
+    onChange(val) {
+      console.log(val)
+    },
     toggleTheme() {
       this.darkTheme = !this.darkTheme
       const page = document.querySelector('html')

--- a/src/templates/Index.vue
+++ b/src/templates/Index.vue
@@ -41,7 +41,7 @@
         </NavGroup>
       </NavBar>
     </header>
-    <section class='p-4 md:p-6'>
+    <article class='p-4 md:p-6'>
       <Heading type='h1'>
         Swayable Design System
       </Heading>
@@ -60,73 +60,111 @@
         </button>
       </p>
 
-      <Heading type='h2'>
-        Typography
-      </Heading>
+      <section>
+        <Heading type='h2'>
+          Typography
+        </Heading>
 
-      <Heading type='h3'>
-        Headings
-      </Heading>
+        <Heading type='h3'>
+          Headings
+        </Heading>
 
-      <table>
-        <thead>
-          <tr>
-            <th>Heading</th>
-            <th>Example</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td><code>&lt;Heading type='h1'&gt;&lt;/Heading&gt;</code></td>
-            <td>
-              <Heading type='h1'>
-                h1. Amazingly few discotheques provide jukeboxes.
-              </Heading>
-            </td>
-          </tr>
-          <tr>
-            <td><code>&lt;Heading type='h2'&gt;&lt;/Heading&gt;</code></td>
-            <td>
-              <Heading type='h2'>
-                h2. Amazingly few discotheques provide jukeboxes.
-              </Heading>
-            </td>
-          </tr>
-          <tr>
-            <td><code>&lt;Heading type='h3'&gt;&lt;/Heading&gt;</code></td>
-            <td>
-              <Heading type='h3'>
-                h3. Amazingly few discotheques provide jukeboxes.
-              </Heading>
-            </td>
-          </tr>
-          <tr>
-            <td><code>&lt;Heading type='h4'&gt;&lt;/Heading&gt;</code></td>
-            <td>
-              <Heading type='h4'>
-                h4. Amazingly few discotheques provide jukeboxes.
-              </Heading>
-            </td>
-          </tr>
-          <tr>
-            <td><code>&lt;Heading type='h5'&gt;&lt;/Heading&gt;</code></td>
-            <td>
-              <Heading type='h5'>
-                h5. Amazingly few discotheques provide jukeboxes.
-              </Heading>
-            </td>
-          </tr>
-          <tr>
-            <td><code>&lt;Heading type='h6'&gt;&lt;/Heading&gt;</code></td>
-            <td>
-              <Heading type='h6'>
-                h6. Amazingly few discotheques provide jukeboxes.
-              </Heading>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </section>
+        <table>
+          <thead>
+            <tr>
+              <th>Heading</th>
+              <th>Example</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>&lt;Heading type='h1'&gt;&lt;/Heading&gt;</code></td>
+              <td>
+                <Heading type='h1'>
+                  h1. Amazingly few discotheques provide jukeboxes.
+                </Heading>
+              </td>
+            </tr>
+            <tr>
+              <td><code>&lt;Heading type='h2'&gt;&lt;/Heading&gt;</code></td>
+              <td>
+                <Heading type='h2'>
+                  h2. Amazingly few discotheques provide jukeboxes.
+                </Heading>
+              </td>
+            </tr>
+            <tr>
+              <td><code>&lt;Heading type='h3'&gt;&lt;/Heading&gt;</code></td>
+              <td>
+                <Heading type='h3'>
+                  h3. Amazingly few discotheques provide jukeboxes.
+                </Heading>
+              </td>
+            </tr>
+            <tr>
+              <td><code>&lt;Heading type='h4'&gt;&lt;/Heading&gt;</code></td>
+              <td>
+                <Heading type='h4'>
+                  h4. Amazingly few discotheques provide jukeboxes.
+                </Heading>
+              </td>
+            </tr>
+            <tr>
+              <td><code>&lt;Heading type='h5'&gt;&lt;/Heading&gt;</code></td>
+              <td>
+                <Heading type='h5'>
+                  h5. Amazingly few discotheques provide jukeboxes.
+                </Heading>
+              </td>
+            </tr>
+            <tr>
+              <td><code>&lt;Heading type='h6'&gt;&lt;/Heading&gt;</code></td>
+              <td>
+                <Heading type='h6'>
+                  h6. Amazingly few discotheques provide jukeboxes.
+                </Heading>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <Heading type='h2'>
+          Form Controls
+        </Heading>
+
+        <Heading type='h3'>
+          Input
+        </Heading>
+
+        <table>
+          <thead>
+            <tr>
+              <th>Input</th>
+              <th>Example</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>&lt;Input placeholder='Placeholder' /&gt;</code></td>
+              <td>
+                <Input placeholder='Placeholder' />
+              </td>
+            </tr>
+            <tr>
+              <td><code>&lt;Input disabled placeholder='Disabled' /&gt;</code></td>
+              <td>
+                <Input
+                  disabled
+                  placeholder='Disabled'
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+    </article>
   </component>
 </template>
 

--- a/src/templates/Index.vue
+++ b/src/templates/Index.vue
@@ -220,7 +220,7 @@
             </tr>
           </tbody>
         </table>
-
+      </section>
     </article>
   </component>
 </template>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -65,6 +65,9 @@ module.exports = {
       maxWidth: sizeMap,
       inset: sizeMap,
       colors,
+      boxShadow: {
+        outline: `0 0 0 2px ${colors['blue-fade']}`,
+      },
     },
     rotate: {
       '1/4': '90deg',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,6 +32,7 @@ const sizeMap = {
   '2/3': '66.6666%',
   '1/4': '25%',
   '3/4': '75%',
+  'full': '100%',
 }
 
 const colors = _reduce(


### PR DESCRIPTION
#### Overview

Adds a dropdown menu pattern.

Note: this does not contain any typeahead/filtering behaviour as that's usually domain specific. This pattern just encompasses the focus/blur handling for the menu, change events when a menu item is clicked, and some styling for the parts of the pattern (list container, list items)

#### Changes

Adds several components which together can be used to build the pattern

- `Dropdown`
- `DropdownMenu`
- `DropdownItem`

#### Screenshots

<details>
<summary>Click to expand</summary>

![Screenshot_2019-10-12 Swayable Design System(2)](https://user-images.githubusercontent.com/1109291/66693062-33200f00-ed01-11e9-97de-dbf5d6da70ea.png)

</details>

