### PR TITLE
feat(Tooltip): add options to delay opening and align with cursor

### DIFF
--- a/src/patterns/ToolTip.vue
+++ b/src/patterns/ToolTip.vue
@@ -1,6 +1,7 @@
 <template>
   <component
     :is='type'
+    ref='trigger'
     class='relative'
     :class='`tooltip-${position}-wrapper`'
     @mouseover='activate'
@@ -52,11 +53,11 @@ export default {
       ].includes(val),
     },
     /**
-     * Opens aligned with the cursor. Otherwise is centered.
+     * Causes tooltip to open aligned with the cursor. Otherwise is centered.
      */
     cursorAlign: {
       type: Boolean,
-      default: true,
+      default: false,
     },
     /**
      * Milliseconds between mouseover and opening
@@ -78,12 +79,14 @@ export default {
     },
   },
   methods: {
-    activate(e) {
+    activate({ clientX, clientY }) {
       if (this.cursorAlign) {
+        const { left, top } = this.$refs.trigger.getBoundingClientRect()
         const positionTopOrBottom = ['top', 'bottom'].includes(this.position)
+
         this.crossAxisPosition = positionTopOrBottom
-          ? { left: `${e.layerX}px`}
-          : { top: `${e.layerY}px`}
+          ? { left: `${clientX - left}px`}
+          : { top: `${clientY - top}px`}
       }
 
       this.state = STATE.opening
@@ -152,7 +155,7 @@ export default {
 <docs>
   ```jsx
   <div class='flex justify-around mb-5'>
-    <ToolTip position='right' :cursorAlign='false' >
+    <ToolTip position='right'>
       <p class='py-1 px-2 rounded border'>Right</p>
       <template #tip>
         <p>Tooltip Right</p>
@@ -164,7 +167,7 @@ export default {
         <p>Tooltip Bottom</p>
       </template>
     </ToolTip>
-    <ToolTip position='left' :cursorAlign='false'>
+    <ToolTip position='left'>
       <p class='py-1 px-2 rounded border'>Left</p>
       <template #tip>
         <p>Tooltip Left</p>
@@ -176,10 +179,10 @@ export default {
         <p>Tooltip Top</p>
       </template>
     </ToolTip>
-    <ToolTip :delay='1000'>
+    <ToolTip :delay='500'>
       <p class='py-1 px-2 rounded border'>Delayed</p>
       <template #tip>
-        <p>by 1 second</p>
+        <p>by half a second</p>
       </template>
     </ToolTip>
   </div>

--- a/src/patterns/ToolTip.vue
+++ b/src/patterns/ToolTip.vue
@@ -52,7 +52,7 @@ export default {
       ].includes(val),
     },
     /**
-     * Opens aligned with the cursor. Otherwise is centered. 
+     * Opens aligned with the cursor. Otherwise is centered.
      */
     cursorAlign: {
       type: Boolean,
@@ -91,7 +91,7 @@ export default {
         if (this.state === STATE.opening) {
           this.state = STATE.open
         }
-      }, this.delay);
+      }, this.delay)
     },
     deactivate() {
       this.state = STATE.closed

--- a/src/patterns/ToolTip.vue
+++ b/src/patterns/ToolTip.vue
@@ -4,8 +4,8 @@
     ref='trigger'
     class='relative'
     :class='`tooltip-${position}-wrapper`'
-    @mouseover='activate'
-    @mouseleave='deactivate'
+    @mouseover='onMouseover'
+    @mouseleave='onMouseleave'
   >
     <slot />
     <transition name='expand'>
@@ -79,25 +79,26 @@ export default {
     },
   },
   methods: {
-    activate({ clientX, clientY }) {
-      if (this.cursorAlign) {
-        const { left, top } = this.$refs.trigger.getBoundingClientRect()
-        const positionTopOrBottom = ['top', 'bottom'].includes(this.position)
-
-        this.crossAxisPosition = positionTopOrBottom
-          ? { left: `${clientX - left}px`}
-          : { top: `${clientY - top}px`}
-      }
-
+    onMouseleave() { this.state = STATE.closed },
+    onMouseover(e) {
+      if (this.cursorAlign) this.alignWithCursor(e)
+      const open = this.delay ? this.openWithDelay : this.open
+      open()
+    },
+    open() { this.state = STATE.open },
+    openWithDelay() {
       this.state = STATE.opening
       setTimeout(() => {
-        if (this.state === STATE.opening) {
-          this.state = STATE.open
-        }
+        if (this.state === STATE.opening) this.open()
       }, this.delay)
     },
-    deactivate() {
-      this.state = STATE.closed
+    alignWithCursor({ clientX, clientY }) {
+      const { left, top } = this.$refs.trigger.getBoundingClientRect()
+      const positionTopOrBottom = ['top', 'bottom'].includes(this.position)
+
+      this.crossAxisPosition = positionTopOrBottom
+        ? { left: `${clientX - left}px`}
+        : { top: `${clientY - top}px`}
     },
   },
 }

--- a/src/patterns/__tests__/__snapshots__/ToolTip.spec.js.snap
+++ b/src/patterns/__tests__/__snapshots__/ToolTip.spec.js.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ToolTip.vue position bottom matches the snapshot 1`] = `
-<div class="relative tooltip-bottom-wrapper"><span></span>
+<div class="relative tooltip-bottom-wrapper">
   <div class="tooltip text-white absolute z-50 rounded-lg py-1 px-2 whitespace-no-wrap tooltip-bottom" style="display: none;" name="expand"></div>
 </div>
 `;
 
 exports[`ToolTip.vue position left matches the snapshot 1`] = `
-<div class="relative tooltip-left-wrapper"><span></span>
+<div class="relative tooltip-left-wrapper">
   <div class="tooltip text-white absolute z-50 rounded-lg py-1 px-2 whitespace-no-wrap tooltip-left" style="display: none;" name="expand"></div>
 </div>
 `;
 
 exports[`ToolTip.vue position right matches the snapshot 1`] = `
-<div class="relative tooltip-right-wrapper"><span></span>
+<div class="relative tooltip-right-wrapper">
   <div class="tooltip text-white absolute z-50 rounded-lg py-1 px-2 whitespace-no-wrap tooltip-right" style="display: none;" name="expand"></div>
 </div>
 `;
 
 exports[`ToolTip.vue position top matches the snapshot 1`] = `
-<div class="relative tooltip-top-wrapper"><span></span>
+<div class="relative tooltip-top-wrapper">
   <div class="tooltip text-white absolute z-50 rounded-lg py-1 px-2 whitespace-no-wrap tooltip-top" style="display: none;" name="expand"></div>
 </div>
 `;


### PR DESCRIPTION
#### Overview
Add tooltip features: delay opening and align with cursor

#### Changes
- add prop `cursorAlign` which, rather than opening the tooltip in the middle of the trigger element, it opens inline with the cursor (good for big triggers like charts)
- add prop `delay` which specifies the number of milliseconds the cursor must hover before the tooltip opens


#### UI
![tooltipimprovements](https://user-images.githubusercontent.com/3292124/67135270-e048ca80-f1cc-11e9-9610-5ac6c51b465b.gif)


